### PR TITLE
3.0 fork

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@ export RUSTFLAGS=-Dwarnings
 
 .PHONY: default check unit-test integration-tests test doc docker-pd docker-kv docker all
 
-PD_ADDRS ?= "127.0.0.1:2379"
-MULTI_REGION ?= 1
+export PD_ADDRS     ?= 127.0.0.1:2379
+export MULTI_REGION ?= 1
 
 ALL_FEATURES := integration-tests
 

--- a/src/common/security.rs
+++ b/src/common/security.rs
@@ -6,6 +6,7 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::time::Duration;
 
+use log::debug;
 use log::info;
 use regex::Regex;
 use tonic::transport::Certificate;
@@ -79,7 +80,7 @@ impl SecurityManager {
     {
         let addr = "http://".to_string() + &SCHEME_REG.replace(addr, "");
 
-        info!("connect to rpc server at endpoint: {:?}", addr);
+        debug!("connect to rpc server at endpoint: {:?}", addr);
 
         let mut builder = Channel::from_shared(addr)?
             .tcp_keepalive(Some(Duration::from_secs(10)))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,6 +156,8 @@ pub use crate::timestamp::TimestampExt;
 #[doc(inline)]
 pub use crate::transaction::lowering as transaction_lowering;
 #[doc(inline)]
+pub use crate::transaction::CommitTTLParameters;
+#[doc(inline)]
 pub use crate::transaction::CheckLevel;
 #[doc(inline)]
 pub use crate::transaction::Client as TransactionClient;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,11 +156,11 @@ pub use crate::timestamp::TimestampExt;
 #[doc(inline)]
 pub use crate::transaction::lowering as transaction_lowering;
 #[doc(inline)]
-pub use crate::transaction::CommitTTLParameters;
-#[doc(inline)]
 pub use crate::transaction::CheckLevel;
 #[doc(inline)]
 pub use crate::transaction::Client as TransactionClient;
+#[doc(inline)]
+pub use crate::transaction::CommitTTLParameters;
 #[doc(inline)]
 pub use crate::transaction::Snapshot;
 #[doc(inline)]

--- a/src/pd/client.rs
+++ b/src/pd/client.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use futures::prelude::*;
 use futures::stream::BoxStream;
-use log::info;
+use log::debug;
 use tokio::sync::RwLock;
 
 use crate::compat::stream_fn;
@@ -347,7 +347,7 @@ impl<Cod: Codec, KvC: KvConnect + Send + Sync + 'static, Cl> PdRpcClient<Cod, Kv
         if let Some(client) = self.kv_client_cache.read().await.get(address) {
             return Ok(client.clone());
         };
-        info!("connect to tikv endpoint: {:?}", address);
+        debug!("connect to tikv endpoint: {:?}", address);
         match self.kv_connect.connect(address).await {
             Ok(client) => {
                 self.kv_client_cache

--- a/src/pd/cluster.rs
+++ b/src/pd/cluster.rs
@@ -6,6 +6,7 @@ use std::time::Duration;
 use std::time::Instant;
 
 use async_trait::async_trait;
+use log::debug;
 use log::error;
 use log::info;
 use log::warn;
@@ -183,7 +184,7 @@ impl Connection {
 
         match members {
             Some(members) => {
-                info!("All PD endpoints are consistent: {:?}", endpoints);
+                debug!("All PD endpoints are consistent: {:?}", endpoints);
                 Ok(members)
             }
             _ => Err(internal_err!("PD cluster failed to respond")),

--- a/src/pd/timestamp.rs
+++ b/src/pd/timestamp.rs
@@ -21,7 +21,6 @@ use futures::task::AtomicWaker;
 use futures::task::Context;
 use futures::task::Poll;
 use log::debug;
-use log::info;
 use pin_project::pin_project;
 use tokio::sync::mpsc;
 use tokio::sync::oneshot;
@@ -107,7 +106,7 @@ async fn run_tso(
         sending_future_waker.wake();
     }
     // TODO: distinguish between unexpected stream termination and expected end of test
-    info!("TSO stream terminated");
+    debug!("TSO stream terminated");
     Ok(())
 }
 

--- a/src/raw/requests.rs
+++ b/src/raw/requests.rs
@@ -16,6 +16,7 @@ use crate::proto::kvrpcpb;
 use crate::proto::kvrpcpb::ApiVersion;
 use crate::proto::metapb;
 use crate::proto::tikvpb::tikv_client::TikvClient;
+use crate::range_request;
 use crate::request::plan::ResponseWithShard;
 use crate::request::Collect;
 use crate::request::CollectSingle;
@@ -23,6 +24,7 @@ use crate::request::DefaultProcessor;
 use crate::request::KvRequest;
 use crate::request::Merge;
 use crate::request::Process;
+use crate::request::RangeRequest;
 use crate::request::Shardable;
 use crate::request::SingleKey;
 use crate::shardable_key;
@@ -227,6 +229,7 @@ impl KvRequest for kvrpcpb::RawDeleteRangeRequest {
     type Response = kvrpcpb::RawDeleteRangeResponse;
 }
 
+range_request!(kvrpcpb::RawDeleteRangeRequest);
 shardable_range!(kvrpcpb::RawDeleteRangeRequest);
 
 pub fn new_raw_scan_request(
@@ -250,6 +253,7 @@ impl KvRequest for kvrpcpb::RawScanRequest {
     type Response = kvrpcpb::RawScanResponse;
 }
 
+range_request!(kvrpcpb::RawScanRequest); // TODO: support reverse raw scan.
 shardable_range!(kvrpcpb::RawScanRequest);
 
 impl Merge<kvrpcpb::RawScanResponse> for Collect {

--- a/src/request/mod.rs
+++ b/src/request/mod.rs
@@ -23,6 +23,7 @@ pub use self::plan_builder::SingleKey;
 pub use self::shard::Batchable;
 pub use self::shard::HasNextBatch;
 pub use self::shard::NextBatch;
+pub use self::shard::RangeRequest;
 pub use self::shard::Shardable;
 use crate::backoff::Backoff;
 use crate::backoff::DEFAULT_REGION_BACKOFF;

--- a/src/store/client.rs
+++ b/src/store/client.rs
@@ -35,7 +35,7 @@ impl KvConnect for TikvConnect {
         self.security_mgr
             .connect(address, TikvClient::new)
             .await
-            .map(|c| KvRpcClient::new(c, self.timeout))
+            .map(|c| KvRpcClient::new(c.max_decoding_message_size(usize::MAX), self.timeout))
     }
 }
 

--- a/src/transaction/client.rs
+++ b/src/transaction/client.rs
@@ -352,7 +352,11 @@ impl<Cod: Codec> Client<Cod> {
 
             info!("scanned {} keys, new range: {:?}", res.len(), range);
 
-            let resolved = resolve_locks(res, self.pd.clone()).await?.len();
+            let to_resolve = res.len();
+
+            let not_resolved = resolve_locks(res, self.pd.clone()).await?.len();
+
+            let resolved = to_resolve - not_resolved;
 
             total_resolved += resolved;
         }

--- a/src/transaction/client.rs
+++ b/src/transaction/client.rs
@@ -348,6 +348,8 @@ impl<Cod: Codec> Client<Cod> {
 
             let mut start_key = res.last().unwrap().key.clone();
             start_key.push(0);
+            
+            info!("scanned {} keys, new start: {:?}", res.len(), start_key);
 
             range.from = Bound::Included(start_key.into());
 

--- a/src/transaction/client.rs
+++ b/src/transaction/client.rs
@@ -348,10 +348,10 @@ impl<Cod: Codec> Client<Cod> {
 
             let mut start_key = res.last().unwrap().key.clone();
             start_key.push(0);
-            
-            info!("scanned {} keys, new start: {:?}", res.len(), start_key);
 
             range.from = Bound::Included(start_key.into());
+            
+            info!("scanned {} keys, new range: {:?}", res.len(), range);
 
             locks.extend(res);
         }

--- a/src/transaction/client.rs
+++ b/src/transaction/client.rs
@@ -305,10 +305,12 @@ impl<Cod: Codec> Client<Cod> {
     ///
     /// This is a simplified version of [GC in TiDB](https://docs.pingcap.com/tidb/stable/garbage-collection-overview).
     /// We omit the second step "delete ranges" which is an optimization for TiDB.
-    pub async fn legacy_gc(&self, safepoint: Timestamp) -> Result<bool> {
-        let resolved = self.legacy_cleanup_locks((..).into(), &safepoint).await?;
+    pub async fn legacy_gc(&self, safepoint: Timestamp, cleanup_locks: bool) -> Result<bool> {
+        if cleanup_locks {
+            let resolved = self.legacy_cleanup_locks((..).into(), &safepoint).await?;
 
-        info!("resolved {resolved} locks, sending new safepoint to PD...");
+            info!("resolved {resolved} locks, sending new safepoint to PD...");
+        }
 
         // update safepoint to PD
         let res: bool = self

--- a/src/transaction/client.rs
+++ b/src/transaction/client.rs
@@ -351,7 +351,7 @@ impl<Cod: Codec> Client<Cod> {
 
             range.from = Bound::Included(start_key.into());
 
-            info!("scanned {} keys, new range: {:?}", res.len(), range);
+            debug!("scanned {} keys, new range: {:?}", res.len(), range);
 
             let to_resolve = res.len();
 

--- a/src/transaction/mod.rs
+++ b/src/transaction/mod.rs
@@ -13,6 +13,7 @@ pub(crate) use lock::resolve_locks;
 pub(crate) use lock::HasLocks;
 pub use snapshot::Snapshot;
 pub use transaction::CheckLevel;
+pub use transaction::CommitTTLParameters;
 #[doc(hidden)]
 pub use transaction::HeartbeatOption;
 pub use transaction::Transaction;

--- a/src/transaction/requests.rs
+++ b/src/transaction/requests.rs
@@ -28,10 +28,12 @@ use crate::request::KvRequest;
 use crate::request::Merge;
 use crate::request::NextBatch;
 use crate::request::Process;
+use crate::request::RangeRequest;
 use crate::request::ResponseWithShard;
 use crate::request::Shardable;
 use crate::request::SingleKey;
 use crate::request::{Batchable, StoreRequest};
+use crate::reversible_range_request;
 use crate::shardable_key;
 use crate::shardable_keys;
 use crate::shardable_range;
@@ -170,6 +172,7 @@ impl KvRequest for kvrpcpb::ScanRequest {
     type Response = kvrpcpb::ScanResponse;
 }
 
+reversible_range_request!(kvrpcpb::ScanRequest);
 shardable_range!(kvrpcpb::ScanRequest);
 
 impl Merge<kvrpcpb::ScanResponse> for Collect {

--- a/src/transaction/transaction.rs
+++ b/src/transaction/transaction.rs
@@ -743,7 +743,7 @@ impl<Cod: Codec, PdC: PdClient<Codec = Cod>> Transaction<Cod, PdC> {
         let request = new_heart_beat_request(
             self.timestamp.clone(),
             primary_key,
-            self.start_instant.elapsed().as_millis() as u64 + MAX_TTL,
+            self.start_instant.elapsed().as_millis() as u64 + self.options.ttl_parameters.max_ttl,
         );
         let encoded_req = EncodedRequest::new(request, self.rpc.get_codec());
         let plan = PlanBuilder::new(self.rpc.clone(), encoded_req)
@@ -828,7 +828,7 @@ impl<Cod: Codec, PdC: PdClient<Codec = Cod>> Transaction<Cod, PdC> {
             keys.clone().into_iter(),
             primary_lock,
             self.timestamp.clone(),
-            MAX_TTL,
+            self.options.ttl_parameters.max_ttl,
             for_update_ts.clone(),
             need_value,
         );
@@ -923,6 +923,7 @@ impl<Cod: Codec, PdC: PdClient<Codec = Cod>> Transaction<Cod, PdC> {
             return;
         }
         self.is_heartbeat_started = true;
+        let max_ttl = self.options.ttl_parameters.max_ttl;
 
         let status = self.status.clone();
         let primary_key = self
@@ -955,7 +956,7 @@ impl<Cod: Codec, PdC: PdClient<Codec = Cod>> Transaction<Cod, PdC> {
                 let request = new_heart_beat_request(
                     start_ts.clone(),
                     primary_key.clone(),
-                    start_instant.elapsed().as_millis() as u64 + MAX_TTL,
+                    start_instant.elapsed().as_millis() as u64 + max_ttl,
                 );
                 let encoded_req = EncodedRequest::new(request, rpc.get_codec());
                 let plan = PlanBuilder::new(rpc.clone(), encoded_req)

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1028,12 +1028,83 @@ async fn txn_scan_reverse() -> Result<()> {
     init().await?;
     let client = TransactionClient::new_with_config(pd_addrs(), Default::default()).await?;
 
+    let k1 = b"k1".to_vec();
+    let k2 = b"k2".to_vec();
+    let k3 = b"k3".to_vec();
+
+    let v1 = b"v1".to_vec();
+    let v2 = b"v2".to_vec();
+    let v3 = b"v3".to_vec();
+
+    // Pessimistic option is not stable in this case. Use optimistic options instead.
+    let option = TransactionOptions::new_optimistic().drop_check(tikv_client::CheckLevel::Warn);
+    let mut t = client.begin_with_options(option.clone()).await?;
+    t.put(k1.clone(), v1.clone()).await?;
+    t.put(k2.clone(), v2.clone()).await?;
+    t.put(k3.clone(), v3.clone()).await?;
+    t.commit().await?;
+
+    let mut t2 = client.begin_with_options(option).await?;
+    {
+        // For [k1, k3]:
+        let bound_range: BoundRange = (k1.clone()..=k3.clone()).into();
+        let resp = t2
+            .scan_reverse(bound_range, 3)
+            .await?
+            .map(|kv| (kv.0, kv.1))
+            .collect::<Vec<(Key, Vec<u8>)>>();
+        assert_eq!(
+            resp,
+            vec![
+                (Key::from(k3.clone()), v3.clone()),
+                (Key::from(k2.clone()), v2.clone()),
+                (Key::from(k1.clone()), v1.clone()),
+            ]
+        );
+    }
+    {
+        // For [k1, k3):
+        let bound_range: BoundRange = (k1.clone()..k3.clone()).into();
+        let resp = t2
+            .scan_reverse(bound_range, 3)
+            .await?
+            .map(|kv| (kv.0, kv.1))
+            .collect::<Vec<(Key, Vec<u8>)>>();
+        assert_eq!(
+            resp,
+            vec![
+                (Key::from(k2.clone()), v2.clone()),
+                (Key::from(k1.clone()), v1),
+            ]
+        );
+    }
+    {
+        // For (k1, k3):
+        let mut start_key = k1.clone();
+        start_key.push(0);
+        let bound_range: BoundRange = (start_key..k3).into();
+        let resp = t2
+            .scan_reverse(bound_range, 3)
+            .await?
+            .map(|kv| (kv.0, kv.1))
+            .collect::<Vec<(Key, Vec<u8>)>>();
+        assert_eq!(resp, vec![(Key::from(k2), v2),]);
+    }
+    t2.commit().await?;
+
+    Ok(())
+}
+
+#[tokio::test]
+#[serial]
+async fn txn_scan_reverse_multi_regions() -> Result<()> {
+    init().await?;
+    let client = TransactionClient::new_with_config(pd_addrs(), Default::default()).await?;
+
     // Keys in `keys` should locate in different regions. See `init()` for boundary of regions.
     let keys: Vec<Key> = vec![
         0x00000000_u32.to_be_bytes().to_vec(),
         0x40000000_u32.to_be_bytes().to_vec(),
-        b"a1".to_vec(), // 0x6149
-        b"a2".to_vec(), // 0x614A
         0x80000000_u32.to_be_bytes().to_vec(),
         0xC0000000_u32.to_be_bytes().to_vec(),
     ]


### PR DESCRIPTION
fork from point of reverse scan fix (which came just after 3.0 version cut)
then cherry pick config ttl changes and max grpc message size
then re-add old `gc` and lock cleanup logic